### PR TITLE
Fix global data offset

### DIFF
--- a/blitzortung/db/query.py
+++ b/blitzortung/db/query.py
@@ -299,8 +299,8 @@ class GlobalGridQuery(SelectQuery):
         )
 
         self.set_columns(
-            'TRUNC((ST_X(ST_Transform(geog::geometry, %(srid)s))) / %(xdiv)s)::integer AS rx',
-            'TRUNC((ST_Y(ST_Transform(geog::geometry, %(srid)s))) / %(ydiv)s)::integer AS ry',
+            'ROUND((ST_X(ST_Transform(geog::geometry, %(srid)s))) / %(xdiv)s)::integer AS rx',
+            'ROUND((ST_Y(ST_Transform(geog::geometry, %(srid)s))) / %(ydiv)s)::integer AS ry',
             'count(*) AS strike_count',
             'max("timestamp") as "timestamp"'
         )

--- a/blitzortung/db/query.py
+++ b/blitzortung/db/query.py
@@ -299,8 +299,8 @@ class GlobalGridQuery(SelectQuery):
         )
 
         self.set_columns(
-            'ROUND((ST_X(ST_Transform(geog::geometry, %(srid)s))) / %(xdiv)s)::integer AS rx',
-            'ROUND((ST_Y(ST_Transform(geog::geometry, %(srid)s))) / %(ydiv)s)::integer AS ry',
+            'ROUND((ST_X(ST_Transform(geog::geometry, %(srid)s)) - %(xdiv)s * 0.5) / %(xdiv)s)::integer AS rx',
+            'ROUND((ST_Y(ST_Transform(geog::geometry, %(srid)s)) - %(ydiv)s * 0.5) / %(ydiv)s)::integer AS ry',
             'count(*) AS strike_count',
             'max("timestamp") as "timestamp"'
         )

--- a/blitzortung/service/strike_grid.py
+++ b/blitzortung/service/strike_grid.py
@@ -132,8 +132,8 @@ class GlobalStrikeGridQuery:
         grid_query.addErrback(log.err)
         return grid_query, state
 
-    @classmethod
-    def build_strikes_grid_result(cls, results, state):
+    @staticmethod
+    def build_strikes_grid_result(results, state):
         state.add_info_text(
             "global grid query %.03fs #%d %s" % (state.get_seconds(), len(results), state.grid_parameters))
         state.log_timing('global_strikes_grid.query')
@@ -142,8 +142,8 @@ class GlobalStrikeGridQuery:
         end_time = state.time_interval.end
         global_strikes_grid_result = tuple(
             (
-                cls._fix_positive_offset(result['rx']) - 1,
-                -cls._fix_positive_offset(result['ry']),
+                result['rx'],
+                -result['ry'],
                 result['strike_count'],
                 -(end_time - result['timestamp']).seconds
             ) for result in results
@@ -152,10 +152,6 @@ class GlobalStrikeGridQuery:
         state.log_timing('globaL_strikes_grid.build_result', reference_time)
 
         return global_strikes_grid_result
-
-    @staticmethod
-    def _fix_positive_offset(value):
-        return value + 1 if value > 0 else value
 
     def combine_result(self, strike_grid_result, histogram_result, state):
         combined_result = gatherResults([strike_grid_result, histogram_result], consumeErrors=True)

--- a/blitzortung/service/strike_grid.py
+++ b/blitzortung/service/strike_grid.py
@@ -143,7 +143,7 @@ class GlobalStrikeGridQuery:
         global_strikes_grid_result = tuple(
             (
                 result['rx'],
-                -result['ry'],
+                -result['ry'] - 1,
                 result['strike_count'],
                 -(end_time - result['timestamp']).seconds
             ) for result in results


### PR DESCRIPTION
We had an error report that there is a strange behaviour near the prime median for global data.

This PR should fix the bad use of `TRUNC` vs `ROUND` in the global data query.